### PR TITLE
minimal fix for jquery selector bug

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -8,7 +8,7 @@ var rightGuess = 0;
 var wrongGuess = 0;
 
 
-$(".container").on("click", "#startBtn", choose);
+$("#startBtn").on("click", null, choose);
 
     function choose() {
         console.log(spentCylons);


### PR DESCRIPTION
https://api.jquery.com/on/

You're registering an onclick handler on class=container. which matches the outermost div.

So every time you click on the button, or the div, or anything inside the div (including the portraits) it fires again.

i.e. You're starting more games with **every** click

this change moves the `data` parameter to the selector, and replaces the `data` parameter with `null` since you're not using it anyway.